### PR TITLE
emailed changes from mum Aug-12 8.30pm

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -131,10 +131,9 @@
                 Counselling offers the opportunity to explore these genuine concerns in a confidential, 
                 non-judgemental setting with someone who is trained to help. 
               </br>
-              Talking through your issues with someone who is really listening and trying to understand how it is for you, 
-              without judging, can make a real difference.
               <br />
-              <br />
+                Talking through your issues with someone who is really listening and trying to understand how it is for you, 
+                without judging, can make a real difference.
             </p>
           </div>
           <div class="w-full sm:w-1/2 p-6">
@@ -180,12 +179,12 @@
                 Why Ski Counselling?
               </h3>
               <p class="text-gray-600 mb-8">
-                <br>I offer counselling to women on a range of issues in regards to their health and overall well-being.</br>
+                <br>We offer counselling to women on a range of issues in regards to their health and overall well-being.</br>
                 
                 <br>Issues that are covered include: Stress Management, Relationship Issues, 
                   Anxiety Post Natal Issues Grief and Bereavement, Self Esteem Building, Time Management, Weight Issues, Other General Counselling.
                 </br>
-                <br>I provide professional counselling to pre teens and adolescents covering issues such as; 
+                <br>We provide professional counselling to pre teens and adolescents covering issues such as; 
                   VCE mentoring during year 12 studies, Self Esteem, Relationship Issues (Including family and friendship) 
                   Anxiety, Stress, Anger, Conflict Resolution, Grief and Bereavement, School Disengagement 
                   and any other counselling issues as requested.
@@ -201,7 +200,7 @@
     <section class="bg-white border-b py-8">
       <div class="container mx-auto flex flex-wrap pt-4 pb-12">
         <h1 class="w-full my-2 text-5xl font-bold leading-tight text-center text-gray-800">
-          <a name="Qualifications">Qualifications</a>
+          <a name="Qualifications">Memberships</a>
         </h1>
         <div class="w-full mb-4">
           <div class="h-1 mx-auto gradient w-64 opacity-25 my-0 py-0 rounded-t"></div>
@@ -209,37 +208,9 @@
         <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
           <div class="flex-1 bg-white rounded-t rounded-b-none overflow-hidden shadow">
             <a href="#" class="flex flex-wrap no-underline hover:no-underline">
-              <div class="w-full font-bold text-xl text-gray-800 px-6">
-                <br>Memberships</br>
-              </div>
               <p class="text-gray-800 text-base px-6 mb-5">
-                <br>Australian Counselling Association MACA (NP)</br> 
+                <br>Australian Counselling Association ACA</br> 
                 <br>Federation of Victorian Counsellors Inc.</br>
-              </p>
-            </a>
-          </div>
-        </div>
-        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-          <div class="flex-1 bg-white rounded-t rounded-b-none overflow-hidden shadow">
-            <a href="#" class="flex flex-wrap no-underline hover:no-underline">
-              <div class="w-full font-bold text-xl text-gray-800 px-6">
-                <br>Higher Education</br>
-              </div>
-              <p class="text-gray-800 text-base px-6 mb-5">
-                <br>Bachelor of Arts, Diploma in Education</br>
-              </p>
-            </a>
-          </div>
-        </div>
-        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-          <div class="flex-1 bg-white rounded-t rounded-b-none overflow-hidden shadow">
-            <a href="#" class="flex flex-wrap no-underline hover:no-underline">
-              <div class="w-full font-bold text-xl text-gray-800 px-6">
-                <br>Certificates and Diplomas</br>
-              </div>
-              <p class="text-gray-800 text-base px-6 mb-5">
-                <br>Certificate in Mental Health for the Teaching Professions</br> 
-                <br>Graduate Diploma in Mental Health for the Teaching Professions</br>
               </p>
             </a>
           </div>
@@ -275,38 +246,63 @@
       <div class="w-full mb-4">
         <div class="h-1 mx-auto bg-white w-1/6 opacity-25 my-0 py-0 rounded-t"></div>
       </div>
-
       <div class="flex flex-wrap">
         <div class="w-5/6 sm:w-1/2 p-6">
           <h1 class="text-3xl text-white-800 font-bold leading-none mb-3">
             Appointments
           </h1>
           <p class="text-white-600 text-left">
-            <br>Please email me to organise an appointment. </br>
-            <br>First appointment is free as we get to know each other and discuss what to expect and how I can help you.</br>
-            <br>If you leave a contact number, I will call you or you can email on the above address.</br>
+            <br>Email or ring for an appointment. </br>
+            <br>If you leave a contact number, I will call you or you can email using the button below</br>
           </p>
+          <button class="mx-auto lg:mx-0 hover:underline bg-white text-gray-800 font-bold rounded-full my-6 py-4 px-8 shadow-lg focus:outline-none focus:shadow-outline transform transition hover:scale-105 duration-300 ease-in-out">
+            <a href="mailto:skicounselling@gmail.com" target="_blank" rel="noopener noreferrer">Email me</a>
+          </button>          
+        </div>
+        <div class="w-5/6 sm:w-1/2 p-6">
+          <h1 class="text-3xl text-white-800 font-bold leading-none mb-3">
+            Agencies who can also help
+          </h1>
+          <br />
+          <ul class="list-reset mb-6">
+            <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+              <a href="http://www.beyondblue.org.au/" class="no-underline hover:underline text-white-800 hover:text-pink-500">Beyond Blue</a>
+            </li>
+            <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+              <a href="http://www.kidshelp.com.au/teens" class="no-underline hover:underline text-white-800 hover:text-pink-500">Kids Help Line</a>
+            </li>
+            <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+              <a href="http://www.headspace.org.au/" class="no-underline hover:underline text-white-800 hover:text-pink-500">Head Space</a>
+            </li>
+            <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+              <a href="http://www.rch.org.au/" class="no-underline hover:underline text-white-800 hover:text-pink-500">Royal Childrens Hospital</a>
+            </li>
+            <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+              <a href="http://www.reachout.com/" class="no-underline hover:underline text-white-800hover:text-pink-500">Reach Out</a>
+            </li>                            
+          </ul>
         </div>
         <div class="w-full sm:w-1/2 p-6">
-          <h1 class="text-3xl text-white-800 font-bold leading-none mb-3">
-            Location
-          </h1>
-          <p class="text-white-600 text-left">
-            <br>Northern Suburbs, Thomastown 3074, Australia</br>
-            <br />
-            <br />
-          </p>
           <h1 class="text-3xl text-white-800 font-bold leading-none mb-3">
             Email Address
           </h1>
           <p class="text-white-600 text-left">
             <br><a href="mailto:skicounselling@gmail.com" target="_blank" rel="noopener noreferrer">skicounselling@gmail.com</br>
-          </p>                 
+          </p>
         </div>
+        <div class="w-5/6 sm:w-1/2 p-6">
+          <h1 class="text-3xl text-white-800 font-bold leading-none mb-3">
+            Location
+          </h1>
+          <p class="text-white-600 text-left">
+            <br>Northern Suburbs, Thomastown 3074, Australia</br>
+          </p>
+          <button class="mx-auto lg:mx-0 hover:underline bg-white text-gray-800 font-bold rounded-full my-6 py-4 px-8 shadow-lg focus:outline-none focus:shadow-outline transform transition hover:scale-105 duration-300 ease-in-out">
+            <a href="https://www.google.com/maps/place/Ski+Counselling+Services/@-37.6849553,144.9850053,17z/data=!3m1!4b1!4m5!3m4!1s0x6ad64f8c745e5e61:0xd90d1b38e8c73f92!8m2!3d-37.6850249!4d144.9872343" target="_blank" rel="noopener noreferrer">Map</a>
+          </button>          
+        </div>        
       </div>
-      <button class="mx-auto lg:mx-0 hover:underline bg-white text-gray-800 font-bold rounded-full my-6 py-4 px-8 shadow-lg focus:outline-none focus:shadow-outline transform transition hover:scale-105 duration-300 ease-in-out">
-        <a href="mailto:skicounselling@gmail.com" target="_blank" rel="noopener noreferrer">Email me</a>
-      </button>
+
     </section>
     <!--Footer-->
     <footer class="bg-white">


### PR DESCRIPTION
Here is my input:

All where I have ‘I’, can you replace that with a ‘we’?

SERVICES: there needs to be a space after the 3rd paragraph and the last one.

QUALIFICATIONS; membership; should read ACA, not MACA  (NP)

                  Actually, I don’t want qualifications. I should only have MEMBERSHIP. Leave Qualifications out.

CONTACT;

where is says: please email me to organise an appointment. Please change it to: email or ring for an appointment.

Please take off that the first session is free. Not on any more.


If you leave a contact number…..       Here the actual email address needs to be included. Not on the other side. What are your thoughts?

I actually want/need the other agencies that people can contact for help:

o   Beyond Blue

o   Kids help line

o   Head Space

o   The Royal Children’s Hospital Melbourne

o   Reach Out